### PR TITLE
Phase 1 PhiKernel integration: add phik adapter, observatories, session & bio layers, and CLI commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,9 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -e .
       - id: version
+        shell: bash
         run: |
-          python - <<'PY'
-          from phios import __version__
-          print(f"version={__version__}")
-          PY >> "$GITHUB_OUTPUT"
+          echo "version=$(python -c 'from phios import __version__; print(__version__)')" >> "$GITHUB_OUTPUT"
       - id: notes
         run: python scripts/generate_release_notes.py
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,36 @@
 
 > “We did not come here to improve the cage. We came here to end it.”
 
-PhiOS is a sovereign computing environment built on Linux, powered by local AI, grounded in TIEKAT mathematics.
+PhiOS is the sovereign operator shell on top of PhiKernel.
 
 Read the manifesto: https://enterthefield.org/phios  
 Built by: PHI369 Labs / Parallax
 
 Sovereign. Coherent. Local. Free.
+
+## PhiOS on PhiKernel
+
+Architecture relationship:
+
+Linux  
+↓  
+PhiKernel = trusted runtime core (source of truth)  
+↓  
+PhiOS = sovereign shell / operator experience
+
+Phase 1 integration is intentionally loose-coupled:
+
+- PhiOS calls PhiKernel via stable CLI interfaces (`phik ... --json`).
+- PhiOS re-renders operator-friendly output and composes workflows.
+- PhiOS does **not** duplicate runtime internals.
+
+PhiKernel remains authoritative for:
+
+- anchor
+- capsules
+- heart
+- coherence
+- routing safety
 
 ## Install
 
@@ -16,24 +40,60 @@ python -m pip install -r requirements.txt
 python -m pip install -e .
 ```
 
+## Verify toolchain
+
+```bash
+phi --help
+phik --help
+phik status --json
+```
+
 ## Quick start
 
 ```bash
 phi
 phi status
 phi coherence
-phi coherence live
+phi ask "How should I begin?"
 phi sovereign export ./phi_snapshot.json
+```
+
+## First Day with PhiOS
+
+```bash
+phi doctor
+phi init --passphrase "change-me" --sovereign-name "Tal-Aren-Vox" --user-label "Ori"
+phi pulse once
+phi status
+phi coherence
+phi ask "How should I begin?"
 ```
 
 ## Command reference (v0.3)
 
 - `phi help`
 - `phi version`
-- `phi status`
-- `phi coherence`
+- `phi doctor [--json]`
+- `phi init --passphrase <value> --sovereign-name <name> --user-label <label> [--resonant-label <label>] [--json]`
+- `phi pulse once [--checkpoint <path>] [--passphrase <value>] [--json]`
+- `phi observatory [--json]`
+- `phi observatory export <path.json>`
+- `phi z map [--json]`
+- `phi mind [--json]`
+- `phi mind map [--json]`
+- `phi mind export <path.json>`
+- `phi session start [--json]`
+- `phi session checkin [--json]`
+- `phi session export <path.json>`
+- `phi bio list [--json]`
+- `phi bio add --name <name> --compound <compound> --source <source> [--dose <dose>] [--unit <unit>] [--timing <timing>] [--notes <notes>] [--json]`
+- `phi bio show [--json]`
+- `phi bio export <path.json>`
+- `phi status [--json]`
+- `phi coherence [--json]`
 - `phi coherence live`
-- `phi sovereign export [path]`
+- `phi ask <prompt> [--json]`
+- `phi sovereign export <path.json>`
 - `phi sovereign verify <path>`
 - `phi sovereign compare <path_a> <path_b>`
 - `phi sovereign annotate <path> <note>`
@@ -44,9 +104,69 @@ phi sovereign export ./phi_snapshot.json
 - `phi kg [stats|search <concept>]`
 - `phi sync [status|push|pull|both]`
 
+
+## Hemavit Observatory
+
+PhiOS can interpret PhiKernel runtime state through a Hemavit / TIEKAT observatory lens.
+This layer is symbolic interpretation and operator workflow composition.
+It does **not** replace PhiKernel's coherence engine or runtime source-of-truth.
+
+```bash
+phi observatory
+phi z map
+phi observatory export ./phi_observatory_snapshot.json
+```
+
+
+## Ψ_mind Observatory
+
+PhiOS can interpret PhiKernel runtime state through a `Ψ_mind` observatory lens.
+This layer is symbolic interpretation and operator workflow composition.
+It does **not** replace PhiKernel's coherence engine or runtime source-of-truth.
+
+```bash
+phi mind
+phi mind map
+phi mind export ./phi_mind_snapshot.json
+```
+
+
+## Session Layer
+
+PhiOS Session Layer is a composition surface across runtime + observatory + mind views.
+It unifies startup and daily check-in workflows while keeping PhiKernel as source-of-truth.
+
+It uses symbolic interpretation terms for operator check-ins, including:
+- `observer_state`
+- `self_alignment`
+- `information_density` (`G_info(I)`)
+- `entropy_load` (`η S_ent`)
+- `emergence_pressure` (`T_emerge`)
+
+```bash
+phi session start
+phi session checkin
+phi session export ./phi_session_snapshot.json
+```
+
+
+## Bioeffector Layer
+
+PhiOS can track compounds / extracts / herbal supports as part of operator workflow.
+This is a local workflow and observatory layer for session correlation, not substrate truth.
+It does **not** replace PhiKernel runtime truth and does **not** constitute medical advice.
+
+```bash
+phi bio add --name "Lion's Mane" --compound "Erinacine A" --source "mycelium" --dose 500 --unit mg --timing morning
+phi bio list
+phi bio show
+phi bio export ./phi_bio_snapshot.json
+```
+
 ## Security posture
 
 - Local-first by default.
 - Unknown command passthrough executes without `shell=True` to reduce injection risk.
-- Sovereign file operations validate paths to prevent relative traversal outside working directory.
+- PhiKernel adapter commands execute with `shell=False` and strict JSON parsing.
+- Sovereign export validates output path shape (`.json`, no `..` traversal segments).
 - No runtime tracking code and no mandatory cloud dependencies.

--- a/phios/adapters/__init__.py
+++ b/phios/adapters/__init__.py
@@ -1,0 +1,2 @@
+"""Adapter layer for external runtime integrations."""
+

--- a/phios/adapters/phik.py
+++ b/phios/adapters/phik.py
@@ -1,0 +1,116 @@
+"""Thin PhiKernel CLI adapter for PhiOS Phase 1 integration.
+
+PhiKernel is the source of truth for runtime state.
+PhiOS consumes PhiKernel command interfaces and owns presentation/workflow composition.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Sequence
+
+
+class PhiKernelAdapterError(RuntimeError):
+    """Base error for PhiKernel adapter failures."""
+
+
+class PhiKernelUnavailableError(PhiKernelAdapterError):
+    """Raised when the `phik` executable is unavailable."""
+
+
+@dataclass(slots=True)
+class PhiKernelCLIAdapter:
+    executable: str = "phik"
+
+    def is_available(self) -> bool:
+        return shutil.which(self.executable) is not None
+
+    def _run_json(self, args: Sequence[str]) -> dict[str, object]:
+        if not self.is_available():
+            raise PhiKernelUnavailableError(
+                "PhiKernel CLI `phik` was not found. Install and initialize PhiKernel first."
+            )
+
+        cmd = [self.executable, *args, "--json"]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                shell=False,
+            )
+        except OSError as exc:
+            raise PhiKernelAdapterError(f"Failed to execute {' '.join(cmd)}: {exc}") from exc
+
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip()
+            stdout = (proc.stdout or "").strip()
+            detail = stderr or stdout or f"exit code {proc.returncode}"
+            raise PhiKernelAdapterError(f"PhiKernel command failed ({' '.join(cmd)}): {detail}")
+
+        raw = (proc.stdout or "").strip()
+        if not raw:
+            return {}
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise PhiKernelAdapterError(
+                f"PhiKernel command returned invalid JSON ({' '.join(cmd)}): {exc.msg}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise PhiKernelAdapterError(
+                f"PhiKernel command returned unexpected payload type ({type(parsed).__name__})."
+            )
+        return parsed
+
+    def status(self) -> dict[str, object]:
+        return self._run_json(["status"])
+
+    def field(self) -> dict[str, object]:
+        return self._run_json(["field"])
+
+    def anchor_show(self) -> dict[str, object]:
+        return self._run_json(["anchor", "show"])
+
+    def capsule_list(self) -> dict[str, object]:
+        return self._run_json(["capsule", "list"])
+
+    def think(self, prompt: str) -> dict[str, object]:
+        return self._run_json(["think", prompt])
+
+    def ask(self, prompt: str) -> dict[str, object]:
+        return self._run_json(["ask", prompt])
+
+    def pulse_once(self, checkpoint: str | None = None, passphrase: str | None = None) -> dict[str, object]:
+        args: list[str] = ["pulse", "once"]
+        if checkpoint:
+            args.extend(["--checkpoint", checkpoint])
+        if passphrase:
+            args.extend(["--passphrase", passphrase])
+        return self._run_json(args)
+
+    def init(
+        self,
+        *,
+        passphrase: str,
+        sovereign_name: str,
+        user_label: str,
+        resonant_label: str | None = None,
+    ) -> dict[str, object]:
+        args = [
+            "init",
+            "--passphrase",
+            passphrase,
+            "--sovereign-name",
+            sovereign_name,
+            "--user-label",
+            user_label,
+        ]
+        if resonant_label:
+            args.extend(["--resonant-label", resonant_label])
+        return self._run_json(args)

--- a/phios/core/bioeffector_layer.py
+++ b/phios/core/bioeffector_layer.py
@@ -1,0 +1,139 @@
+"""PhiOS Bioeffector Layer.
+
+Boundary contract:
+- Bioeffector tracking is a PhiOS workflow/observatory feature.
+- PhiKernel remains the runtime source-of-truth for anchor/heart/coherence/capsules/router safety.
+- Entries here are operator notes and symbolic session support context, not medical advice.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _config_root() -> Path:
+    root = Path(os.environ.get("PHIOS_CONFIG_HOME", str(Path.home())))
+    return root / ".phi"
+
+
+def _store_path() -> Path:
+    return _config_root() / "bioeffectors.json"
+
+
+def _validate_export_path(path_str: str) -> Path:
+    target = Path(path_str).expanduser()
+    if target.suffix.lower() != ".json":
+        raise ValueError("Export path must end with .json")
+    if ".." in target.parts:
+        raise ValueError("Export path may not contain '..' path parts")
+    resolved = target.resolve(strict=False)
+    if resolved.is_dir():
+        raise ValueError("Export path points to a directory")
+    return resolved
+
+
+def _load_entries() -> list[dict[str, object]]:
+    path = _store_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(data, list):
+        return []
+    rows: list[dict[str, object]] = []
+    for item in data:
+        if isinstance(item, dict):
+            rows.append(item)
+    return rows
+
+
+def _save_entries(entries: list[dict[str, object]]) -> None:
+    path = _store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+
+
+def list_bioeffectors() -> list[dict[str, object]]:
+    return _load_entries()
+
+
+def add_bioeffector_entry(
+    *,
+    name: str,
+    compound: str,
+    source: str,
+    dose: str | None = None,
+    unit: str | None = None,
+    timing: str | None = None,
+    notes: str | None = None,
+    formula: str | None = None,
+) -> dict[str, object]:
+    entry: dict[str, object] = {
+        "entry_id": str(uuid.uuid4()),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "name": name,
+        "compound": compound,
+        "source": source,
+        "formula": formula,
+        "dose": dose,
+        "unit": unit,
+        "timing": timing,
+        "notes": notes,
+    }
+    entries = _load_entries()
+    entries.append(entry)
+    _save_entries(entries)
+    return entry
+
+
+def summarize_bioeffectors() -> dict[str, object]:
+    entries = _load_entries()
+    recent_entries = entries[-5:]
+    sources = [str(e.get("source", "unknown")) for e in entries if e.get("source")]
+    timings = [str(e.get("timing", "")) for e in entries if e.get("timing")]
+
+    dominant_source_type = Counter(sources).most_common(1)[0][0] if sources else "none"
+    timing_state = "unspecified"
+    if timings:
+        timing_state = "coordinated" if len(set(timings)) == 1 else "mixed"
+
+    support_vector = "active_support" if len(entries) >= 2 else "baseline"
+    tracking_confidence = "high" if len(entries) >= 3 else "moderate" if entries else "low"
+    session_correlation_readiness = "ready" if len(entries) >= 2 and timing_state != "unspecified" else "forming"
+
+    return {
+        "bioeffector_count": len(entries),
+        "recent_entries": recent_entries,
+        "dominant_source_type": dominant_source_type,
+        "timing_state": timing_state,
+        "bioeffector_mode": "tracking-observatory",
+        "support_vector": support_vector,
+        "tracking_confidence": tracking_confidence,
+        "session_correlation_readiness": session_correlation_readiness,
+    }
+
+
+def export_bioeffector_bundle(path_str: str) -> Path:
+    target = _validate_export_path(path_str)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    entries = _load_entries()
+    summary = summarize_bioeffectors()
+    payload: dict[str, Any] = {
+        "metadata": {
+            "export_version": "1.0",
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "source": "PhiOS Bioeffector Layer",
+        },
+        "entries": entries,
+        "summary": summary,
+    }
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target

--- a/phios/core/hemavit_observatory.py
+++ b/phios/core/hemavit_observatory.py
@@ -1,0 +1,147 @@
+"""Hemavit / TIEKAT observatory interpretation layer for PhiOS.
+
+Boundary contract:
+- PhiKernel remains the runtime source of truth for anchor/heart/coherence/capsules/router safety.
+- PhiOS observatory values here are symbolic interpretations for operator guidance.
+- Z_Hemawit terms are mapping language, not claims of closed physical law.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from phios.adapters.phik import PhiKernelCLIAdapter
+
+
+def _as_int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _capsule_count(capsules: dict[str, object]) -> int:
+    items = capsules.get("capsules", [])
+    if isinstance(items, list):
+        return len(items)
+    count_val = capsules.get("count", 0) or 0
+    return _as_int(count_val, default=0)
+
+
+def _anchor_state(anchor: dict[str, object]) -> str:
+    if any(bool(anchor.get(k)) for k in ("verified", "exists", "present", "initialized")):
+        return "verified"
+    return "missing_or_unverified"
+
+
+def _number(value: object, default: float = 0.0) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default
+
+
+def zhemawit_mapping_table() -> dict[str, str]:
+    return {
+        "C_landscape": "Coherence frame space interpreted from PhiKernel field outputs.",
+        "dμ Consciousness": "Operator observation delta over runtime snapshots and command responses.",
+        "S_ent": "Fragmentation/entropy interpretation from coherence fragmentation signals.",
+        "I_info": "Information-density/quality interpretation from field and route signals.",
+        "Q_vac": "Reserved field-energy namespace for future symbolic expansion.",
+        "O_observer": "Operator + PhiOS shell observation layer over PhiKernel runtime truth.",
+        "R_collapse": "Checkpoint/restore transition risk zone in runtime operations.",
+        "Z_Hemawit": "Total observatory interpretation frame composed by PhiOS from PhiKernel truth.",
+    }
+
+
+def build_observatory_frame(
+    status: dict[str, object],
+    field: dict[str, object],
+    anchor: dict[str, object],
+    capsules: dict[str, object],
+) -> dict[str, object]:
+    _ = status
+    capsule_count = _capsule_count(capsules)
+    fragmentation = _number(field.get("fragmentation_score"), 0.0)
+    distance = _number(field.get("distance_to_C_star"), 0.0)
+    phi_flow = _number(field.get("phi_flow"), 0.0)
+
+    collapse_risk = "elevated" if fragmentation > 0.45 or distance > 0.45 else "managed"
+    observer_stability = "steady" if phi_flow >= 0.5 and collapse_risk == "managed" else "watchful"
+    recognition_readiness = "high" if collapse_risk == "managed" and capsule_count > 0 else "forming"
+
+    return {
+        "anchor_state": _anchor_state(anchor),
+        "current_field_action": field.get("recommended_action", field.get("field_action", "unknown")),
+        "drift_band": field.get("field_band", field.get("drift_band", "unknown")),
+        "capsule_continuity_count": capsule_count,
+        "C_landscape_state": "convergent" if distance <= 0.35 else "transitional",
+        "observer_stability": observer_stability,
+        "entropy_gradient_state": "rising" if fragmentation > 0.35 else "contained",
+        "information_gradient_state": "rich" if phi_flow >= 0.55 else "conserving",
+        "collapse_risk": collapse_risk,
+        "recognition_readiness": recognition_readiness,
+        "zhemawit_mode": "observatory-symbolic",
+    }
+
+
+def build_observatory_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    status = adapter.status()
+    field = adapter.field()
+    anchor = adapter.anchor_show()
+    capsules = adapter.capsule_list()
+    frame = build_observatory_frame(status, field, anchor, capsules)
+    return {
+        "status": status,
+        "field": field,
+        "anchor": anchor,
+        "capsules": capsules,
+        "observatory_frame": frame,
+        "symbolic_mapping": zhemawit_mapping_table(),
+    }
+
+
+def _validate_export_path(path_str: str) -> Path:
+    target = Path(path_str).expanduser()
+    if target.suffix.lower() != ".json":
+        raise ValueError("Export path must end with .json")
+    if ".." in target.parts:
+        raise ValueError("Export path may not contain '..' path parts")
+    resolved = target.resolve(strict=False)
+    if resolved.is_dir():
+        raise ValueError("Export path points to a directory")
+    return resolved
+
+
+def export_observatory_bundle(adapter: PhiKernelCLIAdapter, path_str: str) -> Path:
+    target = _validate_export_path(path_str)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    report = build_observatory_report(adapter)
+    payload: dict[str, Any] = {
+        "metadata": {
+            "export_version": "1.0",
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "source": "PhiOS Hemavit Observatory",
+        },
+        "status": report["status"],
+        "field": report["field"],
+        "observatory_frame": report["observatory_frame"],
+        "symbolic_mapping": report["symbolic_mapping"],
+    }
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target

--- a/phios/core/phik_service.py
+++ b/phios/core/phik_service.py
@@ -1,0 +1,258 @@
+"""PhiOS Phase 1 service composition on top of PhiKernel outputs."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from phios.adapters.phik import (
+    PhiKernelAdapterError,
+    PhiKernelCLIAdapter,
+    PhiKernelUnavailableError,
+)
+
+
+def _as_int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _capsule_count(capsules: dict[str, object]) -> int:
+    capsule_items = capsules.get("capsules", [])
+    if isinstance(capsule_items, list):
+        return len(capsule_items)
+    count_val = capsules.get("count", 0) or 0
+    return _as_int(count_val, default=0)
+
+
+def _anchor_verification_state(status: dict[str, object]) -> object:
+    direct = status.get("anchor_verification_state")
+    if direct is not None:
+        return direct
+    anchor_obj = status.get("anchor")
+    if isinstance(anchor_obj, dict):
+        anchor_dict: dict[str, object] = anchor_obj
+        return anchor_dict.get("verification_state", "unknown")
+    return "unknown"
+
+
+def _heart_state(status: dict[str, object]) -> object:
+    direct = status.get("heart_state")
+    if direct is not None:
+        return direct
+    heart_obj = status.get("heart")
+    if isinstance(heart_obj, dict):
+        heart_dict: dict[str, object] = heart_obj
+        return heart_dict.get("state", "unknown")
+    return "unknown"
+
+
+def build_status_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    status = adapter.status()
+    field = adapter.field()
+    capsules = adapter.capsule_list()
+
+    return {
+        "anchor_verification_state": _anchor_verification_state(status),
+        "heart_state": _heart_state(status),
+        "field_action": field.get("recommended_action", field.get("field_action", "unknown")),
+        "field_drift_band": field.get("field_band", field.get("drift_band", "unknown")),
+        "capsule_count": _capsule_count(capsules),
+        "phik_status": status,
+    }
+
+
+def build_coherence_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    field = adapter.field()
+    return {
+        "C_current": field.get("C_current"),
+        "C_star": field.get("C_star"),
+        "distance_to_C_star": field.get("distance_to_C_star"),
+        "phi_flow": field.get("phi_flow"),
+        "lambda_node": field.get("lambda_node"),
+        "sigma_feedback": field.get("sigma_feedback"),
+        "fragmentation_score": field.get("fragmentation_score"),
+        "recommended_action": field.get("recommended_action"),
+        "phik_field": field,
+    }
+
+
+def build_ask_report(adapter: PhiKernelCLIAdapter, prompt: str) -> dict[str, object]:
+    data = adapter.ask(prompt)
+    return {
+        "prompt": prompt,
+        "coach": data.get("coach"),
+        "field_action": data.get("field_action"),
+        "field_band": data.get("field_band"),
+        "safety_posture": data.get("safety_posture"),
+        "route_reason": data.get("route_reason"),
+        "body": data.get("body"),
+        "next_actions": data.get("next_actions"),
+        "phik_ask": data,
+    }
+
+
+def _anchor_exists(anchor: dict[str, object]) -> bool:
+    candidates = [
+        anchor.get("exists"),
+        anchor.get("present"),
+        anchor.get("initialized"),
+        anchor.get("verified"),
+        anchor.get("anchor_id"),
+    ]
+    return any(bool(item) for item in candidates)
+
+
+def _heart_exists(status: dict[str, object]) -> bool:
+    heart = status.get("heart")
+    if isinstance(heart, dict):
+        heart_dict: dict[str, object] = heart
+        if any(k in heart_dict for k in ("status", "state", "running", "present")):
+            return True
+    heart_state = status.get("heart_state")
+    return bool(heart_state and str(heart_state).lower() not in {"missing", "none", "null"})
+
+
+def build_doctor_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    if not adapter.is_available():
+        return {
+            "status": "missing_phik",
+            "checks": {
+                "phik_callable": False,
+                "anchor_exists": False,
+                "heart_status_exists": False,
+                "coherence_frame_exists": False,
+                "capsule_entries": 0,
+            },
+            "message": "PhiKernel CLI `phik` is missing. Install PhiKernel and initialize before using PhiOS wrappers.",
+        }
+
+    try:
+        status = adapter.status()
+        field = adapter.field()
+        anchor = adapter.anchor_show()
+        capsules = adapter.capsule_list()
+    except PhiKernelUnavailableError:
+        return {
+            "status": "missing_phik",
+            "checks": {
+                "phik_callable": False,
+                "anchor_exists": False,
+                "heart_status_exists": False,
+                "coherence_frame_exists": False,
+                "capsule_entries": 0,
+            },
+            "message": "PhiKernel CLI `phik` is missing. Install PhiKernel and initialize before using PhiOS wrappers.",
+        }
+    except PhiKernelAdapterError as exc:
+        return {
+            "status": "degraded",
+            "checks": {
+                "phik_callable": True,
+                "anchor_exists": False,
+                "heart_status_exists": False,
+                "coherence_frame_exists": False,
+                "capsule_entries": 0,
+            },
+            "message": str(exc),
+        }
+
+    anchor_exists = _anchor_exists(anchor)
+    heart_exists = _heart_exists(status)
+    coherence_exists = bool(field)
+    capsule_entries = _capsule_count(capsules)
+
+    state = "ready"
+    if not anchor_exists:
+        state = "needs_init"
+    elif not heart_exists or not coherence_exists or capsule_entries == 0:
+        state = "needs_pulse"
+
+    return {
+        "status": state,
+        "checks": {
+            "phik_callable": True,
+            "anchor_exists": anchor_exists,
+            "heart_status_exists": heart_exists,
+            "coherence_frame_exists": coherence_exists,
+            "capsule_entries": capsule_entries,
+        },
+        "raw": {
+            "status": status,
+            "field": field,
+            "anchor": anchor,
+            "capsules": capsules,
+        },
+        "message": "PhiKernel readiness inspection completed.",
+    }
+
+
+def run_init(
+    adapter: PhiKernelCLIAdapter,
+    *,
+    passphrase: str,
+    sovereign_name: str,
+    user_label: str,
+    resonant_label: str | None = None,
+) -> dict[str, object]:
+    return adapter.init(
+        passphrase=passphrase,
+        sovereign_name=sovereign_name,
+        user_label=user_label,
+        resonant_label=resonant_label,
+    )
+
+
+def run_pulse_once(
+    adapter: PhiKernelCLIAdapter,
+    *,
+    checkpoint: str | None = None,
+    passphrase: str | None = None,
+) -> dict[str, object]:
+    return adapter.pulse_once(checkpoint=checkpoint, passphrase=passphrase)
+
+
+def _validate_export_path(path_str: str) -> Path:
+    target = Path(path_str).expanduser()
+    if target.suffix.lower() != ".json":
+        raise ValueError("Export path must end with .json")
+
+    if ".." in target.parts:
+        raise ValueError("Export path may not contain '..' path parts")
+
+    resolved = target.resolve(strict=False)
+    if resolved.is_dir():
+        raise ValueError("Export path points to a directory")
+
+    return resolved
+
+
+def export_phase1_bundle(adapter: PhiKernelCLIAdapter, path_str: str) -> Path:
+    target = _validate_export_path(path_str)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, Any] = {
+        "metadata": {
+            "export_version": "1.0",
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "source": "PhiOS Phase 1",
+        },
+        "status": adapter.status(),
+        "field": adapter.field(),
+        "anchor": adapter.anchor_show(),
+        "capsules": adapter.capsule_list(),
+    }
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target

--- a/phios/core/psi_mind_observatory.py
+++ b/phios/core/psi_mind_observatory.py
@@ -1,0 +1,157 @@
+"""Psi-mind observatory interpretation layer for PhiOS.
+
+Boundary contract:
+- PhiKernel remains the runtime source-of-truth for anchor/heart/coherence/capsules/router safety.
+- PhiOS exposes symbolic mind-observatory interpretations for operator ergonomics.
+- Psi-mind/Hemawit terms are runtime mappings, not closed-physics claims.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from phios.adapters.phik import PhiKernelCLIAdapter
+
+
+def _as_int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _number(value: object, default: float = 0.0) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _capsule_count(capsules: dict[str, object]) -> int:
+    items = capsules.get("capsules", [])
+    if isinstance(items, list):
+        return len(items)
+    count_val = capsules.get("count", 0) or 0
+    return _as_int(count_val, default=0)
+
+
+def _anchor_state(anchor: dict[str, object]) -> str:
+    if any(bool(anchor.get(k)) for k in ("verified", "exists", "present", "initialized")):
+        return "verified"
+    return "missing_or_unverified"
+
+
+def psi_mind_mapping_table() -> dict[str, str]:
+    return {
+        "Ψ_mind": "Interpreted current mind-field state from PhiKernel runtime signals.",
+        "V(Ψ)": "Active inner-state potential/affective loading namespace.",
+        "ξRΨ": "Coupling between runtime structure and field state.",
+        "λI": "Information-density interpretation over runtime frame quality.",
+        "ηS_ent": "Entropy/fragmentation interpretation from field signals.",
+        "κC": "Coherence contribution interpreted from PhiKernel field state.",
+        "K(x-y)Ψ(y)": "Symbolic nonlocal memory/retrieval/music-kernel interpretation.",
+        "γ Σ⟨Ψ_i|Ψ_j⟩": "Overlap/relational resonance interpretation.",
+        "L_obs(Ψ,O)": "Observer/operator interaction layer.",
+        "L_topology": "Symbolic high-order topology namespace.",
+        "M_multiverse": "Symbolic branching/possibility namespace.",
+        "R_collapse": "Checkpoint/restore transition zone.",
+    }
+
+
+def build_psi_mind_frame(
+    status: dict[str, object],
+    field: dict[str, object],
+    anchor: dict[str, object],
+    capsules: dict[str, object],
+) -> dict[str, object]:
+    _ = status
+    capsule_count = _capsule_count(capsules)
+    fragmentation = _number(field.get("fragmentation_score"), 0.0)
+    phi_flow = _number(field.get("phi_flow"), 0.0)
+    distance = _number(field.get("distance_to_C_star"), 0.0)
+
+    entropy_load = "high" if fragmentation > 0.45 else "moderate" if fragmentation > 0.25 else "light"
+    information_density = "rich" if phi_flow >= 0.55 else "forming"
+    observer_coupling = "aligned" if distance <= 0.35 else "seeking"
+    collapse_risk = "elevated" if fragmentation > 0.45 or distance > 0.45 else "managed"
+    kernel_resonance = "strong" if phi_flow >= 0.6 and distance <= 0.3 else "present"
+    overlap_strength = "high" if capsule_count >= 3 else "emerging" if capsule_count > 0 else "minimal"
+    recognition_readiness = "high" if collapse_risk == "managed" and capsule_count > 0 else "forming"
+
+    return {
+        "anchor_state": _anchor_state(anchor),
+        "current_field_action": field.get("recommended_action", field.get("field_action", "unknown")),
+        "drift_band": field.get("field_band", field.get("drift_band", "unknown")),
+        "capsule_continuity_count": capsule_count,
+        "psi_mind_state": "coherent" if distance <= 0.35 else "transitional",
+        "observer_coupling": observer_coupling,
+        "entropy_load": entropy_load,
+        "information_density": information_density,
+        "kernel_resonance": kernel_resonance,
+        "overlap_strength": overlap_strength,
+        "collapse_risk": collapse_risk,
+        "recognition_readiness": recognition_readiness,
+        "mind_mode": "psi_mind_observatory",
+    }
+
+
+def build_psi_mind_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    status = adapter.status()
+    field = adapter.field()
+    anchor = adapter.anchor_show()
+    capsules = adapter.capsule_list()
+    frame = build_psi_mind_frame(status, field, anchor, capsules)
+    return {
+        "status": status,
+        "field": field,
+        "anchor": anchor,
+        "capsules": capsules,
+        "mind_observatory_frame": frame,
+        "symbolic_mapping": psi_mind_mapping_table(),
+    }
+
+
+def _validate_export_path(path_str: str) -> Path:
+    target = Path(path_str).expanduser()
+    if target.suffix.lower() != ".json":
+        raise ValueError("Export path must end with .json")
+    if ".." in target.parts:
+        raise ValueError("Export path may not contain '..' path parts")
+    resolved = target.resolve(strict=False)
+    if resolved.is_dir():
+        raise ValueError("Export path points to a directory")
+    return resolved
+
+
+def export_psi_mind_bundle(adapter: PhiKernelCLIAdapter, path_str: str) -> Path:
+    target = _validate_export_path(path_str)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    report = build_psi_mind_report(adapter)
+    payload: dict[str, Any] = {
+        "metadata": {
+            "export_version": "1.0",
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "source": "PhiOS PsiMind Observatory",
+        },
+        "status": report["status"],
+        "field": report["field"],
+        "mind_observatory_frame": report["mind_observatory_frame"],
+        "symbolic_mapping": report["symbolic_mapping"],
+    }
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target

--- a/phios/core/session_layer.py
+++ b/phios/core/session_layer.py
@@ -1,0 +1,210 @@
+"""PhiOS Session Layer composition service.
+
+Boundary contract:
+- PhiKernel remains source-of-truth for runtime state.
+- Session-layer values are PhiOS-level interpretations for operator workflow.
+- Hemawit/observer/self terms are symbolic runtime mappings, not physical-law claims.
+- This layer does not replace PhiKernel runtime engines.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from phios.adapters.phik import PhiKernelCLIAdapter
+from phios.core.hemavit_observatory import build_observatory_report
+from phios.core.phik_service import build_coherence_report, build_status_report
+from phios.core.psi_mind_observatory import build_psi_mind_report
+from phios.core.bioeffector_layer import summarize_bioeffectors
+
+
+def _validate_export_path(path_str: str) -> Path:
+    target = Path(path_str).expanduser()
+    if target.suffix.lower() != ".json":
+        raise ValueError("Export path must end with .json")
+    if ".." in target.parts:
+        raise ValueError("Export path may not contain '..' path parts")
+    resolved = target.resolve(strict=False)
+    if resolved.is_dir():
+        raise ValueError("Export path points to a directory")
+    return resolved
+
+
+def _as_dict(value: object) -> dict[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _entropy_load(fragmentation: object) -> str:
+    frag = float(fragmentation) if isinstance(fragmentation, (int, float)) else 0.0
+    if frag > 0.45:
+        return "high"
+    if frag > 0.25:
+        return "moderate"
+    return "light"
+
+
+def _observer_state(collapse_risk: object) -> str:
+    return "attentive" if collapse_risk == "elevated" else "grounded"
+
+
+def _self_alignment(distance_to_c_star: object) -> str:
+    distance = float(distance_to_c_star) if isinstance(distance_to_c_star, (int, float)) else 0.0
+    if distance <= 0.3:
+        return "aligned"
+    if distance <= 0.5:
+        return "re-centering"
+    return "recovering"
+
+
+def _emergence_pressure(recommended_action: object, collapse_risk: object) -> str:
+    if collapse_risk == "elevated":
+        return "high"
+    if isinstance(recommended_action, str) and recommended_action.lower() not in {"maintain", "hold", "unknown"}:
+        return "building"
+    return "steady"
+
+
+def build_session_start_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    status = build_status_report(adapter)
+    observatory = build_observatory_report(adapter)
+    mind = build_psi_mind_report(adapter)
+
+    observatory_frame = _as_dict(observatory.get("observatory_frame"))
+    mind_frame = _as_dict(mind.get("mind_observatory_frame"))
+
+    collapse_risk = mind_frame.get("collapse_risk", observatory_frame.get("collapse_risk", "managed"))
+    observer_state = _observer_state(collapse_risk)
+    self_alignment = _self_alignment(status.get("field_drift_band"))
+
+    session_state = "watchful" if collapse_risk == "elevated" else "steady"
+
+    # Keep both new and prior key names to preserve existing consumers.
+    return {
+        "session_state": session_state,
+        "anchor_ready": status.get("anchor_verification_state", "unknown"),
+        "heart_ready": status.get("heart_state", "unknown"),
+        "field_action": status.get("field_action", "unknown"),
+        "drift_band": status.get("field_drift_band", "unknown"),
+        "observatory_mode": observatory_frame.get("zhemawit_mode", "unknown"),
+        "mind_mode": mind_frame.get("mind_mode", "unknown"),
+        "observer_state": observer_state,
+        "self_alignment": self_alignment,
+        "next_step": "Run: phi session checkin",
+        "anchor_readiness": status.get("anchor_verification_state", "unknown"),
+        "heart_presence": status.get("heart_state", "unknown"),
+        "next_recommended_step": "Run: phi session checkin",
+        "status": status,
+        "observatory": observatory,
+        "mind": mind,
+    }
+
+
+def build_session_checkin_report(adapter: PhiKernelCLIAdapter) -> dict[str, object]:
+    status = build_status_report(adapter)
+    coherence = build_coherence_report(adapter)
+    observatory = build_observatory_report(adapter)
+    mind = build_psi_mind_report(adapter)
+
+    observatory_state = _as_dict(observatory.get("observatory_frame"))
+    mind_state = _as_dict(mind.get("mind_observatory_frame"))
+
+    field_state = {
+        "action": status.get("field_action", "unknown"),
+        "drift_band": status.get("field_drift_band", "unknown"),
+        "distance_to_C_star": coherence.get("distance_to_C_star"),
+    }
+
+    collapse_risk = mind_state.get("collapse_risk", observatory_state.get("collapse_risk", "managed"))
+    recognition_readiness = mind_state.get(
+        "recognition_readiness",
+        observatory_state.get("recognition_readiness", "forming"),
+    )
+    information_density = mind_state.get("information_density", "forming")
+    entropy_load = mind_state.get("entropy_load", _entropy_load(coherence.get("fragmentation_score")))
+    observer_state = _observer_state(collapse_risk)
+    self_alignment = _self_alignment(coherence.get("distance_to_C_star"))
+    emergence_pressure = _emergence_pressure(status.get("field_action"), collapse_risk)
+    zhemawit_mode = observatory_state.get("zhemawit_mode", "observatory-symbolic")
+
+    bio_summary = summarize_bioeffectors()
+    session_state = "watchful" if collapse_risk == "elevated" else "steady"
+    recommended_action = status.get("field_action", "maintain")
+    recommended_prompt = "What one grounded next step should I take now?"
+    next_step = f'Run: phi ask "{recommended_prompt}"'
+
+    return {
+        "session_state": session_state,
+        "field_state": field_state,
+        "observatory_state": observatory_state,
+        "mind_state": mind_state,
+        "observer_state": observer_state,
+        "self_alignment": self_alignment,
+        "information_density": information_density,
+        "entropy_load": entropy_load,
+        "emergence_pressure": emergence_pressure,
+        "collapse_risk": collapse_risk,
+        "recognition_readiness": recognition_readiness,
+        "recommended_action": recommended_action,
+        "recommended_prompt": recommended_prompt,
+        "next_step": next_step,
+        "zhemawit_mode": zhemawit_mode,
+        "bioeffector_state": bio_summary.get("bioeffector_mode", "tracking-observatory"),
+        "support_vector": bio_summary.get("support_vector", "baseline"),
+        "session_correlation_readiness": bio_summary.get("session_correlation_readiness", "forming"),
+        "status": status,
+        "coherence": coherence,
+        "observatory": observatory,
+        "mind": mind,
+    }
+
+
+def export_session_bundle(adapter: PhiKernelCLIAdapter, path_str: str) -> Path:
+    target = _validate_export_path(path_str)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    status = build_status_report(adapter)
+    coherence = build_coherence_report(adapter)
+    observatory = build_observatory_report(adapter)
+    mind = build_psi_mind_report(adapter)
+    session_summary = build_session_checkin_report(adapter)
+
+    payload: dict[str, Any] = {
+        "metadata": {
+            "export_version": "1.0",
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "source": "PhiOS Session Layer",
+        },
+        "status": status,
+        "coherence": coherence,
+        "hemavit_observatory_frame": observatory.get("observatory_frame", {}),
+        "psi_mind_observatory_frame": mind.get("mind_observatory_frame", {}),
+        "session_summary": {
+            "session_state": session_summary.get("session_state"),
+            "field_state": session_summary.get("field_state"),
+            "recommended_action": session_summary.get("recommended_action"),
+            "recommended_prompt": session_summary.get("recommended_prompt"),
+            "next_step": session_summary.get("next_step"),
+        },
+        "symbolic_session_fields": {
+            "observer_state": session_summary.get("observer_state"),
+            "self_alignment": session_summary.get("self_alignment"),
+            "information_density": session_summary.get("information_density"),
+            "entropy_load": session_summary.get("entropy_load"),
+            "emergence_pressure": session_summary.get("emergence_pressure"),
+            "zhemawit_mode": session_summary.get("zhemawit_mode"),
+            "G_info(I)": session_summary.get("information_density"),
+            "η S_ent": session_summary.get("entropy_load"),
+            "T_emerge": session_summary.get("emergence_pressure"),
+            "O_observer": session_summary.get("observer_state"),
+            "U_self": session_summary.get("self_alignment"),
+            "Z_Hemawit": session_summary.get("zhemawit_mode"),
+            "bioeffector_state": session_summary.get("bioeffector_state"),
+            "support_vector": session_summary.get("support_vector"),
+            "session_correlation_readiness": session_summary.get("session_correlation_readiness"),
+        },
+    }
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target

--- a/phios/shell/phi_commands.py
+++ b/phios/shell/phi_commands.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import platform
 import select
 import subprocess
 import sys
@@ -17,7 +16,38 @@ from pathlib import Path
 from typing import Callable
 
 from phios import __version__
-from phios.core.brainc_client import OLLAMA_URL, BrainCClient, ollama_available
+from phios.core.brainc_client import BrainCClient, ollama_available
+from phios.adapters.phik import PhiKernelCLIAdapter
+from phios.core.phik_service import (
+    build_ask_report,
+    build_coherence_report,
+    build_doctor_report,
+    build_status_report,
+    export_phase1_bundle,
+    run_init,
+    run_pulse_once,
+)
+from phios.core.hemavit_observatory import (
+    build_observatory_report,
+    export_observatory_bundle,
+    zhemawit_mapping_table,
+)
+from phios.core.psi_mind_observatory import (
+    build_psi_mind_report,
+    export_psi_mind_bundle,
+    psi_mind_mapping_table,
+)
+from phios.core.session_layer import (
+    build_session_checkin_report,
+    build_session_start_report,
+    export_session_bundle,
+)
+from phios.core.bioeffector_layer import (
+    add_bioeffector_entry,
+    export_bioeffector_bundle,
+    list_bioeffectors,
+    summarize_bioeffectors,
+)
 from phios.core.lt_engine import compute_lt
 from phios.core.sovereignty import SovereignSnapshot, export_snapshot, verify_snapshot
 from phios.core.tbrc_bridge import TBRCBridge, tbrc_connected
@@ -195,9 +225,25 @@ def cmd_help(_: list[str], session: object | None = None) -> str:
             "Commands:",
             "  help                        Show this help",
             "  version                     Show PhiOS version info",
-            "  status                      Show local system status",
-            "  ask <question|--lt|--session|--next>",
-            "  coherence                   Compute L(t) coherence",
+            "  doctor [--json]             Check PhiKernel readiness",
+            "  init --passphrase ...       Initialize PhiKernel through PhiOS",
+            "  pulse once [--json]         Run single PhiKernel pulse",
+            "  observatory [--json]        Show Hemavit/TIEKAT observatory frame",
+            "  observatory export <path>   Export observatory snapshot",
+            "  z map [--json]              Show Z_Hemawit symbolic mapping table",
+            "  mind [--json]               Show Ψ_mind observatory frame",
+            "  mind map [--json]           Show Ψ_mind symbolic mapping table",
+            "  mind export <path>          Export Ψ_mind snapshot",
+            "  session start [--json]      Show startup session readiness",
+            "  session checkin [--json]    Show integrated daily check-in",
+            "  session export <path>       Export session bundle",
+            "  bio list [--json]            List tracked bioeffector entries",
+            "  bio add ... [--json]         Add a bioeffector tracking entry",
+            "  bio show [--json]            Show bioeffector summary",
+            "  bio export <path>            Export bioeffector layer",
+            "  status [--json]               Show PhiKernel-backed operator status",
+            "  ask <prompt> [--json]         Ask PhiKernel coach",
+            "  coherence [live|--json]       Show PhiKernel coherence field",
             "  coherence live              Launch live coherence monitor",
             "  sovereign export [path]     Export sovereign snapshot",
             "  sovereign verify <path>     Verify sovereign snapshot",
@@ -226,6 +272,368 @@ def cmd_help(_: list[str], session: object | None = None) -> str:
     )
 
 
+
+def _extract_flag_value(args: list[str], flag: str) -> str | None:
+    if flag not in args:
+        return None
+    idx = args.index(flag)
+    if idx + 1 >= len(args):
+        raise ValueError(f"Missing value for {flag}")
+    return args[idx + 1]
+
+
+def cmd_doctor(args: list[str], session: object | None = None) -> str:
+    if "--help" in args or "-h" in args:
+        return "Usage: doctor [--json]"
+
+    report = build_doctor_report(PhiKernelCLIAdapter())
+    if "--json" in args:
+        return json.dumps(report, indent=2)
+
+    checks = report.get("checks", {}) if isinstance(report.get("checks"), dict) else {}
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · PhiKernel Readiness",
+            f"status: {report.get('status', 'unknown')}",
+            f"phik callable: {'yes' if checks.get('phik_callable') else 'no'}",
+            f"anchor exists: {'yes' if checks.get('anchor_exists') else 'no'}",
+            f"heart status: {'yes' if checks.get('heart_status_exists') else 'no'}",
+            f"coherence frame: {'yes' if checks.get('coherence_frame_exists') else 'no'}",
+            f"capsule entries: {checks.get('capsule_entries', 0)}",
+            f"message: {report.get('message', '')}",
+        ]
+    )
+
+
+def cmd_init(args: list[str], session: object | None = None) -> str:
+    if "--help" in args or "-h" in args:
+        return (
+            "Usage: init --passphrase <value> --sovereign-name <name> --user-label <label> "
+            "[--resonant-label <label>] [--json]"
+        )
+
+    passphrase = _extract_flag_value(args, "--passphrase")
+    sovereign_name = _extract_flag_value(args, "--sovereign-name")
+    user_label = _extract_flag_value(args, "--user-label")
+    resonant_label = _extract_flag_value(args, "--resonant-label")
+
+    if not passphrase or not sovereign_name or not user_label:
+        return (
+            "Usage: init --passphrase <value> --sovereign-name <name> --user-label <label> "
+            "[--resonant-label <label>] [--json]"
+        )
+
+    result = run_init(
+        PhiKernelCLIAdapter(),
+        passphrase=passphrase,
+        sovereign_name=sovereign_name,
+        user_label=user_label,
+        resonant_label=resonant_label,
+    )
+
+    if "--json" in args:
+        return json.dumps(result, indent=2)
+
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · Initialization Complete",
+            f"sovereign_name: {sovereign_name}",
+            f"user_label: {user_label}",
+            "PhiKernel remains the runtime source of truth.",
+        ]
+    )
+
+
+def cmd_pulse(args: list[str], session: object | None = None) -> str:
+    if not args or args[0] in {"--help", "-h"}:
+        return "Usage: pulse once [--checkpoint <path>] [--passphrase <value>] [--json]"
+
+    action = args[0]
+    tail = args[1:]
+    if action != "once":
+        return "Usage: pulse once [--checkpoint <path>] [--passphrase <value>] [--json]"
+    if "--help" in tail or "-h" in tail:
+        return "Usage: pulse once [--checkpoint <path>] [--passphrase <value>] [--json]"
+
+    checkpoint = _extract_flag_value(tail, "--checkpoint")
+    passphrase = _extract_flag_value(tail, "--passphrase")
+    if checkpoint and not passphrase:
+        raise ValueError("--passphrase is required when --checkpoint is used")
+
+    result = run_pulse_once(PhiKernelCLIAdapter(), checkpoint=checkpoint, passphrase=passphrase)
+    if "--json" in tail:
+        return json.dumps(result, indent=2)
+
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · Pulse Once",
+            f"field_action: {result.get('field_action', result.get('recommended_action', 'unknown'))}",
+            f"field_band: {result.get('field_band', result.get('drift_band', 'unknown'))}",
+            f"route_reason: {result.get('route_reason', 'n/a')}",
+        ]
+    )
+
+
+def cmd_observatory(args: list[str], session: object | None = None) -> str:
+    if args and args[0] in {"--help", "-h"}:
+        return "Usage: observatory [--json] | observatory export <path.json>"
+
+    if args and args[0] == "export":
+        if len(args) > 1 and args[1] in {"--help", "-h"}:
+            return "Usage: observatory export <path.json>"
+        if len(args) < 2:
+            return "Usage: observatory export <path.json>"
+        out_path = export_observatory_bundle(PhiKernelCLIAdapter(), args[1])
+        return f"✓ Hemavit observatory bundle written: {out_path}"
+
+    report = build_observatory_report(PhiKernelCLIAdapter())
+    if "--json" in args:
+        return json.dumps(report, indent=2)
+
+    frame = report.get("observatory_frame", {}) if isinstance(report.get("observatory_frame"), dict) else {}
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · Hemavit Observatory",
+            "Boundary: PhiKernel is source-of-truth; PhiOS provides symbolic interpretation.",
+            f"anchor_state: {frame.get('anchor_state', 'unknown')}",
+            f"current_field_action: {frame.get('current_field_action', 'unknown')}",
+            f"drift_band: {frame.get('drift_band', 'unknown')}",
+            f"capsule_continuity_count: {frame.get('capsule_continuity_count', 0)}",
+            f"C_landscape_state: {frame.get('C_landscape_state', 'unknown')}",
+            f"observer_stability: {frame.get('observer_stability', 'unknown')}",
+            f"entropy_gradient_state: {frame.get('entropy_gradient_state', 'unknown')}",
+            f"information_gradient_state: {frame.get('information_gradient_state', 'unknown')}",
+            f"collapse_risk: {frame.get('collapse_risk', 'unknown')}",
+            f"recognition_readiness: {frame.get('recognition_readiness', 'unknown')}",
+            f"zhemawit_mode: {frame.get('zhemawit_mode', 'unknown')}",
+        ]
+    )
+
+
+def cmd_z(args: list[str], session: object | None = None) -> str:
+    if not args or args[0] in {"--help", "-h"}:
+        return "Usage: z map [--json]"
+
+    action = args[0]
+    tail = args[1:]
+    if action != "map":
+        return "Usage: z map [--json]"
+    if "--help" in tail or "-h" in tail:
+        return "Usage: z map [--json]"
+
+    mapping = zhemawit_mapping_table()
+    if "--json" in tail:
+        return json.dumps({"symbolic_mapping": mapping}, indent=2)
+
+    lines = [
+        "PHI369 Labs / Parallax · Z_Hemawit Symbolic Map",
+        "Symbolic documentation and runtime introspection (not a physics simulator).",
+    ]
+    for k, v in mapping.items():
+        lines.append(f"{k} -> {v}")
+    return "\n".join(lines)
+
+
+def cmd_mind(args: list[str], session: object | None = None) -> str:
+    if args and args[0] in {"--help", "-h"}:
+        return "Usage: mind [--json] | mind map [--json] | mind export <path.json>"
+
+    if args and args[0] == "map":
+        tail = args[1:]
+        if "--help" in tail or "-h" in tail:
+            return "Usage: mind map [--json]"
+        mapping = psi_mind_mapping_table()
+        if "--json" in tail:
+            return json.dumps({"symbolic_mapping": mapping}, indent=2)
+        lines = [
+            "PHI369 Labs / Parallax · Ψ_mind Symbolic Map",
+            "Symbolic documentation/runtime introspection (not a simulator).",
+        ]
+        for k, v in mapping.items():
+            lines.append(f"{k} -> {v}")
+        return "\n".join(lines)
+
+    if args and args[0] == "export":
+        if len(args) > 1 and args[1] in {"--help", "-h"}:
+            return "Usage: mind export <path.json>"
+        if len(args) < 2:
+            return "Usage: mind export <path.json>"
+        out_path = export_psi_mind_bundle(PhiKernelCLIAdapter(), args[1])
+        return f"✓ Ψ_mind observatory bundle written: {out_path}"
+
+    report = build_psi_mind_report(PhiKernelCLIAdapter())
+    if "--json" in args:
+        return json.dumps(report, indent=2)
+
+    frame = report.get("mind_observatory_frame", {}) if isinstance(report.get("mind_observatory_frame"), dict) else {}
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · Ψ_mind Observatory",
+            "Boundary: PhiKernel is source-of-truth; PhiOS provides symbolic interpretation.",
+            f"anchor_state: {frame.get('anchor_state', 'unknown')}",
+            f"current_field_action: {frame.get('current_field_action', 'unknown')}",
+            f"drift_band: {frame.get('drift_band', 'unknown')}",
+            f"capsule_continuity_count: {frame.get('capsule_continuity_count', 0)}",
+            f"psi_mind_state: {frame.get('psi_mind_state', 'unknown')}",
+            f"observer_coupling: {frame.get('observer_coupling', 'unknown')}",
+            f"entropy_load: {frame.get('entropy_load', 'unknown')}",
+            f"information_density: {frame.get('information_density', 'unknown')}",
+            f"kernel_resonance: {frame.get('kernel_resonance', 'unknown')}",
+            f"overlap_strength: {frame.get('overlap_strength', 'unknown')}",
+            f"collapse_risk: {frame.get('collapse_risk', 'unknown')}",
+            f"recognition_readiness: {frame.get('recognition_readiness', 'unknown')}",
+            f"mind_mode: {frame.get('mind_mode', 'unknown')}",
+        ]
+    )
+
+
+def cmd_session(args: list[str], session: object | None = None) -> str:
+    if not args or args[0] in {"--help", "-h"}:
+        return "Usage: session <start|checkin|export> ..."
+
+    action = args[0]
+    tail = args[1:]
+
+    if action == "start":
+        if "--help" in tail or "-h" in tail:
+            return "Usage: session start [--json]"
+        report = build_session_start_report(PhiKernelCLIAdapter())
+        if "--json" in tail:
+            return json.dumps(report, indent=2)
+        return "\n".join(
+            [
+                "PHI369 Labs / Parallax · Session Start",
+                f"session_state: {report.get('session_state', 'unknown')}",
+                f"anchor_ready: {report.get('anchor_ready', report.get('anchor_readiness', 'unknown'))}",
+                f"heart_ready: {report.get('heart_ready', report.get('heart_presence', 'unknown'))}",
+                f"field_action: {report.get('field_action', 'unknown')}",
+                f"drift_band: {report.get('drift_band', 'unknown')}",
+                f"observatory_mode: {report.get('observatory_mode', 'unknown')}",
+                f"mind_mode: {report.get('mind_mode', 'unknown')}",
+                f"observer_state: {report.get('observer_state', 'unknown')}",
+                f"self_alignment: {report.get('self_alignment', 'unknown')}",
+                f"next_step: {report.get('next_step', report.get('next_recommended_step', ''))}",
+            ]
+        )
+
+    if action == "checkin":
+        if "--help" in tail or "-h" in tail:
+            return "Usage: session checkin [--json]"
+        report = build_session_checkin_report(PhiKernelCLIAdapter())
+        if "--json" in tail:
+            return json.dumps(report, indent=2)
+        return "\n".join(
+            [
+                "PHI369 Labs / Parallax · Session Check-in",
+                f"session_state: {report.get('session_state', 'unknown')}",
+                f"observer_state: {report.get('observer_state', 'unknown')}",
+                f"self_alignment: {report.get('self_alignment', 'unknown')}",
+                f"information_density: {report.get('information_density', 'unknown')}",
+                f"entropy_load: {report.get('entropy_load', 'unknown')}",
+                f"emergence_pressure: {report.get('emergence_pressure', 'unknown')}",
+                f"collapse_risk: {report.get('collapse_risk', 'unknown')}",
+                f"recognition_readiness: {report.get('recognition_readiness', 'unknown')}",
+                f"zhemawit_mode: {report.get('zhemawit_mode', 'unknown')}",
+                f"recommended_action: {report.get('recommended_action', 'unknown')}",
+                f"recommended_prompt: {report.get('recommended_prompt', '')}",
+                f"next_step: {report.get('next_step', '')}",
+            ]
+        )
+
+    if action == "export":
+        if len(tail) > 0 and tail[0] in {"--help", "-h"}:
+            return "Usage: session export <path.json>"
+        if not tail:
+            return "Usage: session export <path.json>"
+        out_path = export_session_bundle(PhiKernelCLIAdapter(), tail[0])
+        return f"✓ Session bundle written: {out_path}"
+
+    return "Usage: session <start|checkin|export> ..."
+
+
+def cmd_bio(args: list[str], session: object | None = None) -> str:
+    if not args or args[0] in {"--help", "-h"}:
+        return "Usage: bio <list|add|show|export> ..."
+
+    action = args[0]
+    tail = args[1:]
+
+    if action == "list":
+        if "--help" in tail or "-h" in tail:
+            return "Usage: bio list [--json]"
+        rows = list_bioeffectors()
+        if "--json" in tail:
+            return json.dumps({"entries": rows}, indent=2)
+        if not rows:
+            return "No bioeffector entries tracked yet."
+        lines = ["PHI369 Labs / Parallax · Bioeffectors"]
+        for row in rows[-9:]:
+            lines.append(f"- {row.get('name', 'unknown')} · {row.get('compound', 'n/a')} · {row.get('source', 'n/a')}")
+        return "\n".join(lines)
+
+    if action == "add":
+        if "--help" in tail or "-h" in tail:
+            return (
+                "Usage: bio add --name <name> --compound <compound> --source <source> "
+                "[--dose <dose>] [--unit <unit>] [--timing <timing>] [--notes <notes>] [--json]"
+            )
+
+        name = _extract_flag_value(tail, "--name")
+        compound = _extract_flag_value(tail, "--compound")
+        source = _extract_flag_value(tail, "--source")
+        dose = _extract_flag_value(tail, "--dose")
+        unit = _extract_flag_value(tail, "--unit")
+        timing = _extract_flag_value(tail, "--timing")
+        notes = _extract_flag_value(tail, "--notes")
+
+        if not name or not compound or not source:
+            return (
+                "Usage: bio add --name <name> --compound <compound> --source <source> "
+                "[--dose <dose>] [--unit <unit>] [--timing <timing>] [--notes <notes>] [--json]"
+            )
+
+        entry = add_bioeffector_entry(
+            name=name,
+            compound=compound,
+            source=source,
+            dose=dose,
+            unit=unit,
+            timing=timing,
+            notes=notes,
+        )
+        if "--json" in tail:
+            return json.dumps({"entry": entry}, indent=2)
+        return f"Bioeffector entry added: {entry.get('name')} ({entry.get('compound')})"
+
+    if action == "show":
+        if "--help" in tail or "-h" in tail:
+            return "Usage: bio show [--json]"
+        summary = summarize_bioeffectors()
+        if "--json" in tail:
+            return json.dumps(summary, indent=2)
+        return "\n".join(
+            [
+                "PHI369 Labs / Parallax · Bioeffector Summary",
+                f"bioeffector_count: {summary.get('bioeffector_count', 0)}",
+                f"dominant_source_type: {summary.get('dominant_source_type', 'none')}",
+                f"timing_state: {summary.get('timing_state', 'unspecified')}",
+                f"bioeffector_mode: {summary.get('bioeffector_mode', 'tracking-observatory')}",
+                f"support_vector: {summary.get('support_vector', 'baseline')}",
+                f"tracking_confidence: {summary.get('tracking_confidence', 'low')}",
+                f"session_correlation_readiness: {summary.get('session_correlation_readiness', 'forming')}",
+            ]
+        )
+
+    if action == "export":
+        if len(tail) > 0 and tail[0] in {"--help", "-h"}:
+            return "Usage: bio export <path.json>"
+        if not tail:
+            return "Usage: bio export <path.json>"
+        out = export_bioeffector_bundle(tail[0])
+        return f"✓ Bioeffector bundle written: {out}"
+
+    return "Usage: bio <list|add|show|export> ..."
+
 def cmd_version(_: list[str], session: object | None = None) -> str:
     return "\n".join(
         [
@@ -253,18 +661,22 @@ def _format_uptime() -> str:
         return "unknown"
 
 
-def cmd_status(_: list[str], session: object | None = None) -> str:
-    ai_status = "yes" if ollama_available() else "no"
-    t_word = "Tele" + "metry"
+def cmd_status(args: list[str], session: object | None = None) -> str:
+    if "--help" in args or "-h" in args:
+        return "Usage: status [--json]"
+
+    report = build_status_report(PhiKernelCLIAdapter())
+    if "--json" in args:
+        return json.dumps(report, indent=2)
+
     return "\n".join(
         [
-            f"OS: {platform.platform()}",
-            f"Python: {platform.python_version()}",
-            f"CPU count: {os.cpu_count()}",
-            f"Memory total: {_format_memory()}",
-            f"Uptime: {_format_uptime()}",
-            f"Local AI ({OLLAMA_URL}): {ai_status}",
-            f"{t_word}: OFF (enforced)",
+            "PHI369 Labs / Parallax · PhiOS Operator Status",
+            f"Anchor verification: {report.get('anchor_verification_state', 'unknown')}",
+            f"Heart state: {report.get('heart_state', 'unknown')}",
+            f"Field action / drift band: {report.get('field_action', 'unknown')} / {report.get('field_drift_band', 'unknown')}",
+            f"Capsules tracked: {report.get('capsule_count', 0)}",
+            "Source of truth: PhiKernel",
         ]
     )
 
@@ -274,18 +686,25 @@ def cmd_coherence(args: list[str], session: object | None = None) -> str:
         if session is None:
             return "Live mode requires session context"
         return cmd_coherence_live(session)
+    if "--help" in args or "-h" in args:
+        return "Usage: coherence [live|--json]"
 
-    data = compute_lt()
-    c = data["components"]
-    if session is not None:
-        history = list(getattr(session, "coherence_history", []))
-        history.append(float(data["lt"]))
-        setattr(session, "coherence_history", history[-9:])
-    return (
-        f"L(t): {data['lt']:.6f}\n"
-        f"A_stability: {c['A_stability']:.6f}\n"
-        f"G_load: {c['G_load']:.6f}\n"
-        f"C_variance: {c['C_variance']:.6f}"
+    report = build_coherence_report(PhiKernelCLIAdapter())
+    if "--json" in args:
+        return json.dumps(report, indent=2)
+
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · Coherence Report",
+            f"C_current: {report.get('C_current')}",
+            f"C_star: {report.get('C_star')}",
+            f"distance_to_C_star: {report.get('distance_to_C_star')}",
+            f"phi_flow: {report.get('phi_flow')}",
+            f"lambda_node: {report.get('lambda_node')}",
+            f"sigma_feedback: {report.get('sigma_feedback')}",
+            f"fragmentation_score: {report.get('fragmentation_score')}",
+            f"recommended_action: {report.get('recommended_action')}",
+        ]
     )
 
 
@@ -340,23 +759,12 @@ def cmd_sovereign(args: list[str], session: object | None = None) -> str:
         return f"Sovereign mode: {'ON' if target else 'OFF'}"
 
     if action == "export":
-        if session is None:
-            session_data = {"history": [], "duration_s": 0, "commands_run": 0, "resonance_moments_hit": 0, "trajectory": "stable"}
-        else:
-            session_data = {
-                "history": list(getattr(session, "coherence_history", [])),
-                "duration_s": int(getattr(session, "elapsed_seconds", lambda: 0)()),
-                "commands_run": int(getattr(session, "commands_run", 0)),
-                "resonance_moments_hit": int(getattr(session, "resonance_moments_hit", 0)),
-                "trajectory": str(getattr(session, "trajectory", "stable")),
-            }
-        lt = compute_lt()
-        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        out_path = args[1] if len(args) > 1 else f"./phi_snapshot_{stamp}.json"
-        data = snapper.capture(lt, session_data)
-        Path(out_path).write_text(json.dumps(data, indent=2), encoding="utf-8")
-        short_hash = data.get("integrity", {}).get("content_hash", "")[:6]
-        return f"✓ Snapshot captured · L(t): {float(lt.get('lt', 0.0)):.3f} · Hash: {short_hash}..."
+        if len(args) > 1 and args[1] in {"--help", "-h"}:
+            return "Usage: sovereign export <path.json>"
+        if len(args) < 2:
+            return "Usage: sovereign export <path.json>"
+        out_path = export_phase1_bundle(PhiKernelCLIAdapter(), args[1])
+        return f"✓ Phase 1 export bundle written: {out_path}"
 
     if action == "verify":
         if len(args) < 2:
@@ -529,7 +937,9 @@ def cmd_ask(args: list[str], session: object | None = None) -> str:
     client = BrainCClient()
     ctx = _build_ask_context(session)
     if not args:
-        return "Usage: ask <question|--lt|--session|--next>"
+        return "Usage: ask <prompt> [--json]"
+    if "--help" in args or "-h" in args:
+        return "Usage: ask <prompt> [--json]"
 
     if args[0] == "--lt":
         return client.ask_about_lt(compute_lt())
@@ -539,10 +949,33 @@ def cmd_ask(args: list[str], session: object | None = None) -> str:
         suggestion = client.suggest_next_command(list(ctx.get("recent_commands", [])), float(ctx.get("lt_score", 0.5)))
         return suggestion
 
-    question = " ".join(args).strip()
-    response = client.ask(question, stream=True, context=ctx)
-    NOTIFIER.notify("brainc_response", "BrainC response complete", f"Model: {response.model}")
-    return response.answer
+    json_mode = "--json" in args
+    prompt_parts = [a for a in args if a != "--json"]
+    question = " ".join(prompt_parts).strip()
+    report = build_ask_report(PhiKernelCLIAdapter(), question)
+
+    if json_mode:
+        return json.dumps(report, indent=2)
+
+    next_actions = report.get("next_actions") or []
+    if not isinstance(next_actions, list):
+        next_actions = [str(next_actions)]
+    actions_lines = "\n".join([f"  - {item}" for item in next_actions]) if next_actions else "  - (none)"
+
+    return "\n".join(
+        [
+            "PHI369 Labs / Parallax · Ask",
+            f"coach: {report.get('coach')}",
+            f"field_action / band: {report.get('field_action')} / {report.get('field_band')}",
+            f"safety_posture: {report.get('safety_posture')}",
+            f"route_reason: {report.get('route_reason')}",
+            "",
+            str(report.get("body", "")),
+            "",
+            "next_actions:",
+            actions_lines,
+        ]
+    )
 
 
 def cmd_launcher(args: list[str], session: object | None = None) -> str:
@@ -845,6 +1278,14 @@ def cmd_build(args: list[str], session: object | None = None) -> str:
 COMMANDS: dict[str, CommandHandler] = {
     "help": cmd_help,
     "version": cmd_version,
+    "doctor": cmd_doctor,
+    "init": cmd_init,
+    "pulse": cmd_pulse,
+    "observatory": cmd_observatory,
+    "z": cmd_z,
+    "mind": cmd_mind,
+    "session": cmd_session,
+    "bio": cmd_bio,
     "status": cmd_status,
     "ask": cmd_ask,
     "coherence": cmd_coherence,

--- a/phios/shell/phi_router.py
+++ b/phios/shell/phi_router.py
@@ -15,6 +15,9 @@ def route_command(argv: Sequence[str], session: object | None = None) -> tuple[s
     if not argv:
         return "", 0
 
+    if argv[0] in ("--help", "-h"):
+        return COMMANDS["help"]([], session=session), 0
+
     cmd = argv[0]
     args = list(argv[1:])
     if cmd in ("exit", "quit"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 phi = "phios.shell.phi_session:main"
 
 [tool.setuptools]
-packages = ["phios", "phios.shell", "phios.core", "phios.display", "phios.desktop"]
+packages = ["phios", "phios.shell", "phios.core", "phios.display", "phios.desktop", "phios.adapters"]
 
 [tool.setuptools.dynamic]
 version = {attr = "phios.__version__"}

--- a/tests/test_v01_shell_core.py
+++ b/tests/test_v01_shell_core.py
@@ -21,12 +21,25 @@ def test_lt_engine_range():
     assert 0.0 <= val <= 1.0
 
 
-def test_coherence_speed_ci_threshold():
+def test_coherence_speed_ci_threshold(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_coherence_report",
+        lambda *_: {
+            "C_current": 0.61,
+            "C_star": 0.9,
+            "distance_to_C_star": 0.29,
+            "phi_flow": 0.5,
+            "lambda_node": 0.4,
+            "sigma_feedback": 0.2,
+            "fragmentation_score": 0.1,
+            "recommended_action": "stabilize",
+        },
+    )
     start = time.perf_counter()
     out, code = route_command(["coherence"])
     elapsed = time.perf_counter() - start
     assert code == 0
-    assert "L(t):" in out
+    assert "C_current:" in out
     assert elapsed < 0.2
 
 
@@ -53,10 +66,20 @@ def test_brainc_status_no_raise():
     assert "brainc:" in out
 
 
-def test_status_required_fields():
+def test_status_required_fields(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_status_report",
+        lambda *_: {
+            "anchor_verification_state": "verified",
+            "heart_state": "running",
+            "field_action": "maintain",
+            "field_drift_band": "green",
+            "capsule_count": 3,
+        },
+    )
     out, code = route_command(["status"])
     assert code == 0
-    required = ["OS:", "Python:", "CPU count:", "Memory total:", "Uptime:", "Local AI", "Telemetry: OFF (enforced)"]
+    required = ["Anchor verification:", "Heart state:", "Field action / drift band:", "Capsules tracked:"]
     for item in required:
         assert item in out
 

--- a/tests/test_v06_brainc_launcher.py
+++ b/tests/test_v06_brainc_launcher.py
@@ -55,13 +55,24 @@ def test_brainc_never_raises_on_connection_error(monkeypatch):
 
 
 def test_phi_ask_streams_or_returns_string(monkeypatch):
-    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("x")))
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_ask_report",
+        lambda *_: {
+            "coach": "SovereignCoach",
+            "field_action": "maintain",
+            "field_band": "green",
+            "safety_posture": "safe",
+            "route_reason": "local",
+            "body": "Operator guidance.",
+            "next_actions": ["phi status"],
+        },
+    )
     f = io.StringIO()
     with redirect_stdout(f):
         out, code = route_command(["ask", "what is phi?"])
     assert code == 0
     assert isinstance(out, str)
-    assert "No data left this machine." in out
+    assert "Operator guidance." in out
 
 
 def test_phi_ask_lt_returns_interpretation(monkeypatch):

--- a/tests/test_v11_phase1_phik_integration.py
+++ b/tests/test_v11_phase1_phik_integration.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from phios.adapters.phik import PhiKernelCLIAdapter, PhiKernelUnavailableError
+from phios.shell.phi_router import route_command
+
+
+def test_phi_status_parses_wrapped_phik_status_json(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_status_report",
+        lambda *_: {
+            "anchor_verification_state": "verified",
+            "heart_state": "running",
+            "field_action": "hold",
+            "field_drift_band": "green",
+            "capsule_count": 2,
+        },
+    )
+    out, code = route_command(["status", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["anchor_verification_state"] == "verified"
+
+
+def test_phi_coherence_parses_wrapped_phik_field_json(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_coherence_report",
+        lambda *_: {
+            "C_current": 0.62,
+            "C_star": 0.9,
+            "distance_to_C_star": 0.28,
+            "phi_flow": 0.41,
+            "lambda_node": 0.38,
+            "sigma_feedback": 0.11,
+            "fragmentation_score": 0.09,
+            "recommended_action": "stabilize",
+        },
+    )
+    out, code = route_command(["coherence", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["recommended_action"] == "stabilize"
+
+
+def test_phi_ask_parses_wrapped_phik_ask_json(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_ask_report",
+        lambda *_: {
+            "coach": "SovereignCoach",
+            "field_action": "maintain",
+            "field_band": "green",
+            "safety_posture": "safe",
+            "route_reason": "deterministic",
+            "body": "Begin with a stable baseline.",
+            "next_actions": ["phi status", "phi coherence"],
+        },
+    )
+    out, code = route_command(["ask", "How should I begin?", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["coach"] == "SovereignCoach"
+
+
+def test_phi_sovereign_export_writes_valid_json_bundle(monkeypatch, tmp_path):
+    output = tmp_path / "bundle.json"
+
+    def fake_export(_, path: str):
+        payload = {
+            "metadata": {"export_version": "1.0", "source": "PhiOS Phase 1"},
+            "status": {},
+            "field": {},
+            "anchor": {},
+            "capsules": {},
+        }
+        out = tmp_path / path.split("/")[-1]
+        out.write_text(json.dumps(payload), encoding="utf-8")
+        return out
+
+    monkeypatch.setattr("phios.shell.phi_commands.export_phase1_bundle", fake_export)
+    out, code = route_command(["sovereign", "export", str(output)])
+    assert code == 0
+    assert "Phase 1 export bundle" in out
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["metadata"]["source"] == "PhiOS Phase 1"
+
+
+def test_missing_phik_produces_clean_error(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda *_: None)
+    with pytest.raises(PhiKernelUnavailableError):
+        PhiKernelCLIAdapter().status()
+
+
+def test_adapter_never_uses_shell_true(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda *_: "/usr/bin/phik")
+
+    def fake_run(*args, **kwargs):
+        assert kwargs.get("shell") is False
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    data = PhiKernelCLIAdapter().status()
+    assert data == {}
+
+
+def test_doctor_when_phik_missing(monkeypatch):
+    monkeypatch.setattr("phios.shell.phi_commands.build_doctor_report", lambda *_: {"status": "missing_phik", "checks": {"phik_callable": False, "anchor_exists": False, "heart_status_exists": False, "coherence_frame_exists": False, "capsule_entries": 0}, "message": "missing"})
+    out, code = route_command(["doctor", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["status"] == "missing_phik"
+
+
+def test_doctor_when_anchor_missing(monkeypatch):
+    monkeypatch.setattr("phios.shell.phi_commands.build_doctor_report", lambda *_: {"status": "needs_init", "checks": {"phik_callable": True, "anchor_exists": False, "heart_status_exists": False, "coherence_frame_exists": False, "capsule_entries": 0}, "message": "init required"})
+    out, code = route_command(["doctor"])
+    assert code == 0
+    assert "status: needs_init" in out
+
+
+def test_init_successful_wrapping_behavior(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.run_init",
+        lambda *_args, **_kwargs: {"ok": True, "anchor": "created"},
+    )
+    out, code = route_command(
+        [
+            "init",
+            "--passphrase",
+            "change-me",
+            "--sovereign-name",
+            "Tal-Aren-Vox",
+            "--user-label",
+            "Ori",
+        ]
+    )
+    assert code == 0
+    assert "Initialization Complete" in out
+
+
+def test_init_existing_anchor_failure_passthrough(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.run_init",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("anchor already initialized")),
+    )
+    out, code = route_command(
+        [
+            "init",
+            "--passphrase",
+            "change-me",
+            "--sovereign-name",
+            "Tal-Aren-Vox",
+            "--user-label",
+            "Ori",
+        ]
+    )
+    assert code == 1
+    assert "anchor already initialized" in out
+
+
+def test_pulse_once_successful_wrapping_behavior(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.run_pulse_once",
+        lambda *_args, **_kwargs: {"field_action": "stabilize", "field_band": "green", "route_reason": "safe"},
+    )
+    out, code = route_command(["pulse", "once"])
+    assert code == 0
+    assert "Pulse Once" in out
+
+
+def test_pulse_once_checkpoint_path(monkeypatch):
+    captured = {}
+
+    def fake_pulse(*_args, **kwargs):
+        captured.update(kwargs)
+        return {"field_action": "stabilize", "field_band": "green", "route_reason": "safe"}
+
+    monkeypatch.setattr("phios.shell.phi_commands.run_pulse_once", fake_pulse)
+    out, code = route_command(["pulse", "once", "--checkpoint", "./cp.json", "--passphrase", "change-me"])
+    assert code == 0
+    assert captured["checkpoint"] == "./cp.json"
+    assert captured["passphrase"] == "change-me"
+
+
+def test_json_output_contracts_for_new_commands(monkeypatch):
+    monkeypatch.setattr("phios.shell.phi_commands.build_doctor_report", lambda *_: {"status": "ready"})
+    monkeypatch.setattr("phios.shell.phi_commands.run_init", lambda *_args, **_kwargs: {"ok": True})
+    monkeypatch.setattr("phios.shell.phi_commands.run_pulse_once", lambda *_args, **_kwargs: {"ok": True})
+
+    doc_out, doc_code = route_command(["doctor", "--json"])
+    init_out, init_code = route_command([
+        "init",
+        "--passphrase",
+        "change-me",
+        "--sovereign-name",
+        "Tal-Aren-Vox",
+        "--user-label",
+        "Ori",
+        "--json",
+    ])
+    pulse_out, pulse_code = route_command(["pulse", "once", "--json"])
+
+    assert doc_code == 0 and init_code == 0 and pulse_code == 0
+    assert json.loads(doc_out)["status"] == "ready"
+    assert json.loads(init_out)["ok"] is True
+    assert json.loads(pulse_out)["ok"] is True
+
+
+def test_observatory_wraps_phik_backed_data(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_observatory_report",
+        lambda *_: {
+            "observatory_frame": {
+                "anchor_state": "verified",
+                "current_field_action": "stabilize",
+                "drift_band": "green",
+                "capsule_continuity_count": 3,
+                "C_landscape_state": "convergent",
+                "observer_stability": "steady",
+                "entropy_gradient_state": "contained",
+                "information_gradient_state": "rich",
+                "collapse_risk": "managed",
+                "recognition_readiness": "high",
+                "zhemawit_mode": "observatory-symbolic",
+            },
+            "symbolic_mapping": {"Z_Hemawit": "frame"},
+        },
+    )
+    out, code = route_command(["observatory"])
+    assert code == 0
+    assert "Hemavit Observatory" in out
+    assert "anchor_state: verified" in out
+
+
+def test_z_map_returns_expected_mapping_table(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.zhemawit_mapping_table",
+        lambda: {"C_landscape": "coherence frame space", "Z_Hemawit": "total frame"},
+    )
+    out, code = route_command(["z", "map", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert "C_landscape" in data["symbolic_mapping"]
+
+
+def test_observatory_export_writes_valid_json(monkeypatch, tmp_path):
+    output = tmp_path / "obs.json"
+
+    def fake_export(_, path: str):
+        payload = {
+            "metadata": {"export_version": "1.0", "source": "PhiOS Hemavit Observatory"},
+            "status": {},
+            "field": {},
+            "observatory_frame": {"zhemawit_mode": "observatory-symbolic"},
+            "symbolic_mapping": {"Z_Hemawit": "frame"},
+        }
+        out = tmp_path / path.split("/")[-1]
+        out.write_text(json.dumps(payload), encoding="utf-8")
+        return out
+
+    monkeypatch.setattr("phios.shell.phi_commands.export_observatory_bundle", fake_export)
+    out, code = route_command(["observatory", "export", str(output)])
+    assert code == 0
+    assert "observatory bundle" in out
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["metadata"]["source"] == "PhiOS Hemavit Observatory"
+
+
+def test_observatory_missing_phik_fails_cleanly(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_observatory_report",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("PhiKernel CLI `phik` was not found")),
+    )
+    out, code = route_command(["observatory"])
+    assert code == 1
+    assert "phik" in out.lower()
+
+
+def test_mind_wraps_phik_backed_data(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_psi_mind_report",
+        lambda *_: {
+            "mind_observatory_frame": {
+                "anchor_state": "verified",
+                "current_field_action": "stabilize",
+                "drift_band": "green",
+                "capsule_continuity_count": 2,
+                "psi_mind_state": "coherent",
+                "observer_coupling": "aligned",
+                "entropy_load": "light",
+                "information_density": "rich",
+                "kernel_resonance": "strong",
+                "overlap_strength": "emerging",
+                "collapse_risk": "managed",
+                "recognition_readiness": "high",
+                "mind_mode": "psi_mind_observatory",
+            }
+        },
+    )
+    out, code = route_command(["mind"])
+    assert code == 0
+    assert "Ψ_mind Observatory" in out
+    assert "psi_mind_state: coherent" in out
+
+
+def test_mind_map_returns_expected_mapping_table(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.psi_mind_mapping_table",
+        lambda: {"Ψ_mind": "state", "κC": "coherence contribution"},
+    )
+    out, code = route_command(["mind", "map", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert "Ψ_mind" in data["symbolic_mapping"]
+
+
+def test_mind_export_writes_valid_json(monkeypatch, tmp_path):
+    output = tmp_path / "mind.json"
+
+    def fake_export(_, path: str):
+        payload = {
+            "metadata": {"export_version": "1.0", "source": "PhiOS PsiMind Observatory"},
+            "status": {},
+            "field": {},
+            "mind_observatory_frame": {"mind_mode": "psi_mind_observatory"},
+            "symbolic_mapping": {"Ψ_mind": "state"},
+        }
+        out = tmp_path / path.split("/")[-1]
+        out.write_text(json.dumps(payload), encoding="utf-8")
+        return out
+
+    monkeypatch.setattr("phios.shell.phi_commands.export_psi_mind_bundle", fake_export)
+    out, code = route_command(["mind", "export", str(output)])
+    assert code == 0
+    assert "Ψ_mind observatory bundle" in out
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["metadata"]["source"] == "PhiOS PsiMind Observatory"
+
+
+def test_mind_missing_phik_fails_cleanly(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_psi_mind_report",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("PhiKernel CLI `phik` was not found")),
+    )
+    out, code = route_command(["mind"])
+    assert code == 1
+    assert "phik" in out.lower()
+
+
+def test_session_start_returns_valid_startup_report(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_session_start_report",
+        lambda *_: {
+            "session_state": "steady",
+            "anchor_ready": "verified",
+            "heart_ready": "running",
+            "field_action": "maintain",
+            "drift_band": "green",
+            "observatory_mode": "observatory-symbolic",
+            "mind_mode": "psi_mind_observatory",
+            "observer_state": "grounded",
+            "self_alignment": "aligned",
+            "next_step": "Run: phi session checkin",
+        },
+    )
+    out, code = route_command(["session", "start", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["anchor_ready"] == "verified"
+
+
+def test_session_checkin_returns_integrated_report(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_session_checkin_report",
+        lambda *_: {
+            "session_state": "steady",
+            "field_state": {"action": "maintain"},
+            "observatory_state": {"zhemawit_mode": "observatory-symbolic"},
+            "mind_state": {"mind_mode": "psi_mind_observatory"},
+            "observer_state": "grounded",
+            "self_alignment": "aligned",
+            "information_density": "rich",
+            "entropy_load": "light",
+            "emergence_pressure": "steady",
+            "collapse_risk": "managed",
+            "recognition_readiness": "high",
+            "recommended_action": "maintain",
+            "recommended_prompt": "What one grounded next step should I take now?",
+            "next_step": "Run: phi ask",
+            "zhemawit_mode": "observatory-symbolic",
+        },
+    )
+    out, code = route_command(["session", "checkin", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["session_state"] == "steady"
+
+
+def test_session_export_writes_valid_json(monkeypatch, tmp_path):
+    output = tmp_path / "session.json"
+
+    def fake_export(_, path: str):
+        payload = {
+            "metadata": {"export_version": "1.0", "source": "PhiOS Session Layer"},
+            "status": {},
+            "coherence": {},
+            "hemavit_observatory_frame": {},
+            "psi_mind_observatory_frame": {},
+            "session_summary": {"session_state": "steady"},
+            "symbolic_session_fields": {"observer_state": "grounded"},
+        }
+        out = tmp_path / path.split("/")[-1]
+        out.write_text(json.dumps(payload), encoding="utf-8")
+        return out
+
+    monkeypatch.setattr("phios.shell.phi_commands.export_session_bundle", fake_export)
+    out, code = route_command(["session", "export", str(output)])
+    assert code == 0
+    assert "Session bundle written" in out
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["metadata"]["source"] == "PhiOS Session Layer"
+
+
+def test_session_missing_phik_fails_cleanly(monkeypatch):
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_session_start_report",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("PhiKernel CLI `phik` was not found")),
+    )
+    out, code = route_command(["session", "start"])
+    assert code == 1
+    assert "phik" in out.lower()
+
+
+
+def test_bio_add_writes_valid_entry(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHIOS_CONFIG_HOME", str(tmp_path))
+    out, code = route_command([
+        "bio",
+        "add",
+        "--name",
+        "Lion's Mane",
+        "--compound",
+        "Erinacine A",
+        "--source",
+        "mycelium",
+        "--dose",
+        "500",
+        "--unit",
+        "mg",
+        "--timing",
+        "morning",
+        "--json",
+    ])
+    assert code == 0
+    data = json.loads(out)
+    assert data["entry"]["name"] == "Lion's Mane"
+
+
+def test_bio_list_returns_stored_entries(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHIOS_CONFIG_HOME", str(tmp_path))
+    _ = route_command([
+        "bio",
+        "add",
+        "--name",
+        "Custom Stack",
+        "--compound",
+        "Beta-glucan",
+        "--source",
+        "extract",
+    ])
+    out, code = route_command(["bio", "list", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert len(data["entries"]) >= 1
+
+
+def test_bio_show_returns_valid_summary_structure(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHIOS_CONFIG_HOME", str(tmp_path))
+    _ = route_command([
+        "bio",
+        "add",
+        "--name",
+        "Entry A",
+        "--compound",
+        "Hericenone",
+        "--source",
+        "fruiting body",
+        "--timing",
+        "morning",
+    ])
+    out, code = route_command(["bio", "show", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    for key in [
+        "bioeffector_count",
+        "recent_entries",
+        "dominant_source_type",
+        "timing_state",
+        "bioeffector_mode",
+        "support_vector",
+        "tracking_confidence",
+        "session_correlation_readiness",
+    ]:
+        assert key in data
+
+
+def test_bio_export_writes_valid_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHIOS_CONFIG_HOME", str(tmp_path))
+    _ = route_command([
+        "bio",
+        "add",
+        "--name",
+        "Entry B",
+        "--compound",
+        "Erinacine-rich mycelium",
+        "--source",
+        "mycelium",
+    ])
+    output = tmp_path / "bio_snapshot.json"
+    out, code = route_command(["bio", "export", str(output)])
+    assert code == 0
+    assert "Bioeffector bundle written" in out
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["metadata"]["source"] == "PhiOS Bioeffector Layer"
+
+
+def test_session_layer_still_passes_without_bio_entries(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHIOS_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "phios.shell.phi_commands.build_session_checkin_report",
+        lambda *_: {
+            "session_state": "steady",
+            "field_state": {"action": "maintain"},
+            "observatory_state": {},
+            "mind_state": {},
+            "observer_state": "grounded",
+            "self_alignment": "aligned",
+            "information_density": "forming",
+            "entropy_load": "light",
+            "emergence_pressure": "steady",
+            "collapse_risk": "managed",
+            "recognition_readiness": "forming",
+            "recommended_action": "maintain",
+            "recommended_prompt": "next",
+            "next_step": "Run",
+            "zhemawit_mode": "observatory-symbolic",
+            "bioeffector_state": "tracking-observatory",
+            "support_vector": "baseline",
+            "session_correlation_readiness": "forming",
+        },
+    )
+    out, code = route_command(["session", "checkin", "--json"])
+    assert code == 0
+    data = json.loads(out)
+    assert data["session_state"] == "steady"


### PR DESCRIPTION
### Motivation

- Add Phase 1 integration surface so PhiOS can consume PhiKernel (`phik`) as the runtime source-of-truth and provide operator-facing composition and exports. 
- Provide symbolic observatory and session layers (Hemavit / Ψ_mind / Session) plus a lightweight bioeffector tracking layer for operator workflows. 
- Expose these features via the shell so operators can `doctor`, `init`, `pulse`, inspect observatories, run session check-ins, and export Phase 1 bundles.

### Description

- Introduce a thin CLI adapter `PhiKernelCLIAdapter` in `phios.adapters.phik` that runs `phik` without `shell=True`, parses JSON, and surfaces clear errors like `PhiKernelUnavailableError` and `PhiKernelAdapterError`.
- Add core Phase 1 services and observatories: `phios/core/phik_service.py`, `phios/core/hemavit_observatory.py`, `phios/core/psi_mind_observatory.py`, `phios/core/session_layer.py`, and `phios/core/bioeffector_layer.py` implementing reporting, exports, and simple interpretation logic.
- Update the shell CLI in `phios/shell/phi_commands.py` to wire new commands and wrappers (`doctor`, `init`, `pulse`, `observatory`, `z map`, `mind`, `session`, `bio`, and revised `status`, `ask`, `coherence`) that call the new services and support `--json` output.
- Add lightweight router help handling in `phios/shell/phi_router.py`, include `phios.adapters` package in `pyproject.toml`, add module docstrings, and expand `README.md` with Phase 1 architecture and usage examples.
- Adjust CI release step to set output `version` via a compact `echo` call, and add/modify test coverage to reflect the new integration surface.

### Testing

- Ran unit tests with `pytest` including updated tests `tests/test_v01_shell_core.py` and `tests/test_v06_brainc_launcher.py` and the newly added `tests/test_v11_phase1_phik_integration.py`, which exercise CLI wrapping, JSON output contracts, exports, and adapter behavior.
- Tests simulate `phik` via monkeypatching and assert JSON output and CLI return codes for commands like `status`, `coherence`, `ask`, `doctor`, `init`, `pulse`, `observatory`, `mind`, `session`, and `bio`.
- Adapter behavior tests confirm `subprocess.run` is called with `shell=False` and that missing `phik` raises `PhiKernelUnavailableError`.
- All automated tests completed successfully (no failing tests reported during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2481280e083289e1147608298e470)